### PR TITLE
Fix dblclick triggers when inside input field

### DIFF
--- a/views/admin/transaction-single.hbs
+++ b/views/admin/transaction-single.hbs
@@ -31,6 +31,10 @@
 <script>
     document.querySelectorAll("table tr[changable] td:nth-child(2)").forEach(function (node) {
         node.ondblclick = function () {
+            // If the td node has children, it likely has an input node & is being edited
+            if (this.children.length)
+                return;
+
             var val = this.innerHTML;
             var input = document.createElement("input");
             input.value = val;


### PR DESCRIPTION
Split PR from #4:
- Fixes bug on `/admin/transactions/:id` when user double clicks again in the input