### PR TITLE
Implement multifile upload to transaction page

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "node-sass-middleware": "^0.11.0",
     "passport": "^0.4.1",
     "passport-google-oauth": "^2.0.0",
-    "socket.io": "^2.3.0"
+    "socket.io": "^2.3.0",
+    "upath": "^1.2.0"
   },
   "_moduleAliases": {
     "@libs": "./src/libs",

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -71,28 +71,30 @@ app.post('/transactions/:id', (req, res) => {
 
 app.post(
   '/transactions/receipt/:id',
-  upload.single('file'),
+  upload.any(),
   (req, res) => {
     const data = {
-      Receipt: [
-        {
-          url: config.host + '/' + req.file.path
+      Receipt: req.files.map(file => {
+        return {
+          url: config.host + '/' + file.path
         }
-      ]
+      })
     }
 
     db.updateTx(req.params.id, data).then((result) => {
-      setTimeout(() => {
-        fs.unlink(req.file.path, (err) => {
-          if (err) {
-            console.log(err)
-            res.status(500)
-          }
+      req.files.forEach(file => {
+        setTimeout(() => {
+          fs.unlink(file.path, (err) => {
+            if (err) {
+              console.log(err)
+              res.status(500)
+            }
 
-          console.log('Deleted file at ' + req.file.path)
-          res.status(200)
-        })
-      }, 10000) // Delete after 10 seconds
+            console.log('Deleted file at ' + file.path)
+            res.status(200)
+          })
+        }, 10000) // Delete after 10 seconds
+      })
     }).finally(() => {
       res.status(200).send(req.file);
     })

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2,6 +2,7 @@ const express = require('express')
 const multer = require('multer')
 const mime = require('mime-types')
 const fs = require('fs')
+const upath = require('upath')
 const app = express.Router()
 
 const storage = multer.diskStorage({
@@ -76,7 +77,7 @@ app.post(
     const data = {
       Receipt: req.files.map(file => {
         return {
-          url: config.host + '/' + file.path
+          url: config.host + '/' + upath.normalize(file.path)
         }
       })
     }

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -55,13 +55,13 @@ app.get('/transactions', (req, res) => {
 
 app.get('/transactions/:id', (req, res) => {
   db.findTxById(req.params.id).then((d) => {
-    if (d['Receipt']) {
-      d['Receipt'] = d['Receipt'][0]['url']
-    }
+    const receipts = d['Receipt']
+    delete d['Receipt']
 
     res.render('admin/transaction-single', {
       title: `Tx #${d['Tx ID']}`,
-      tx: d
+      tx: d,
+      receipts
     })
   })
 })

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -257,7 +257,7 @@ h1.site-title {
 
 .transaction-single {
   width: 100%;
-  
+
   tr {
     &[changable] {
       td:first-child {
@@ -270,6 +270,18 @@ h1.site-title {
         color: lightslategray;
       }
     }
+  }
+}
+
+.receipts {
+  h1 {
+    margin-bottom: 8px;
+  }
+
+  img {
+    width: 128px;
+    vertical-align: middle;
+    margin-right: 12px;
   }
 }
 

--- a/views/admin/transaction-single.hbs
+++ b/views/admin/transaction-single.hbs
@@ -19,7 +19,7 @@
         <form id="receipt" action="/admin/transactions/receipt/{{tx.id}}" method="POST"
             class="dropzone needsclick dz-clickable" enctype="multipart/form-data">
             <div class="dz-message">
-                <button class="dz-button" type="button">Upload Receipt Here (Single File)</button>
+                <button class="dz-button" type="button">Upload Receipt(s) Here</button>
             </div>
             <div class="fallback">
                 <input name="file" type="file" multiple />
@@ -28,7 +28,12 @@
     </div>
 </div>
 
+<script src="/static/assets/js/dropzone.min.js"></script>
 <script>
+    Dropzone.options.receipt = {
+        uploadMultiple: true
+    }
+
     document.querySelectorAll("table tr[changable] td:nth-child(2)").forEach(function (node) {
         node.ondblclick = function () {
             var val = this.innerHTML;
@@ -60,7 +65,3 @@
         }
     });
 </script>
-
-{{#extend "foot-inject"}}
-<script src="/static/assets/js/dropzone.min.js"></script>
-{{/extend}}

--- a/views/admin/transaction-single.hbs
+++ b/views/admin/transaction-single.hbs
@@ -28,6 +28,16 @@
     </div>
 </div>
 
+<div class="receipts">
+    <h1>Receipts</h1>
+
+    {{#each receipts}}
+    <a href={{this.url}} target="_blank">
+        <img src={{this.thumbnails.large.url}} alt="" />
+    </a>
+    {{/each}}
+</div>
+
 <script src="/static/assets/js/dropzone.min.js"></script>
 <script>
     Dropzone.options.receipt = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,6 +2260,11 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+upath@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"


### PR DESCRIPTION
Split PR from #4:
- Implements multiple file uploads & adds receipt section to `/admin/transactions/:id`
- Windows paths have `\\`, which messes up the file upload paths, so file paths are normalized to unix (doesn't matter too much since prod is probably not Windows so ¯\\(ツ)/¯)