### PR TITLE
Fully log all headers

### DIFF
--- a/src/libs/middlewares.js
+++ b/src/libs/middlewares.js
@@ -12,9 +12,8 @@ const logger = (req, res, next) => {
         ? req.connection.socket.remoteAddress
         : null)
 
-    console.log(
-      `User at ${req.ip} accessed ${req.originalUrl}`
-    )
+    console.log(`User at ${req.ip} accessed ${req.originalUrl}`)
+    console.log(JSON.stringify(req.headers));
   }
 
   next()


### PR DESCRIPTION
Making this change to fish out the Airtable requests' headers, so we can securely store our files.