### PR TITLE
Secure uploads with temporary URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,4 +200,5 @@ $RECYCLE.BIN/
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
 static/uploaded/*
+temp/uploaded/*
 static/assets/css/style.css

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ app.get("/denied", (req, res) => {
 })
 app.use("/api", require("@routes/api"))
 app.use("/auth", require("@routes/auth"))
+app.use("/uploads", require("@routes/uploads"))
 app.use("/admin", middlewares.isUserAuthenticated , require("@routes/admin"))
 
 server.listen(config.port, () => {

--- a/src/libs/middlewares.js
+++ b/src/libs/middlewares.js
@@ -13,7 +13,6 @@ const logger = (req, res, next) => {
         : null)
 
     console.log(`User at ${req.ip} accessed ${req.originalUrl}`)
-    console.log(JSON.stringify(req.headers));
   }
 
   next()

--- a/src/libs/pathstore.js
+++ b/src/libs/pathstore.js
@@ -1,0 +1,22 @@
+const PATH_DICT = {}
+
+// generates random forwarding path
+const generatePath = (fileName) => {
+  const fwdPath =
+    Math.random().toString(36).substring(2, 15) +
+    Math.random().toString(36).substring(2, 15)
+  PATH_DICT[fwdPath] = fileName
+
+  return fwdPath
+}
+
+const getPath = (pathName) => {
+    console.log(PATH_DICT)
+    realPath = PATH_DICT[pathName]
+    console.log(realPath)
+    delete PATH_DICT[pathName]
+
+    return realPath
+}
+
+module.exports = {generatePath, getPath}

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -6,7 +6,7 @@ const app = express.Router()
 
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    cb(null, './static/uploaded')
+    cb(null, './temp/uploaded')
   },
   filename: function (req, file, cb) {
     const uniqueSuffix =
@@ -27,6 +27,7 @@ const account = require('@services/account')
 const db = require('@services/airtable')
 const clog = require('@services/clog')
 const tx = require('@libs/tx')
+const pathStore = require('@libs/pathstore')
 const config = require('@config')
 const { result } = require('lodash')
 
@@ -74,27 +75,17 @@ app.post(
   '/transactions/receipt/:id',
   upload.single('file'),
   (req, res) => {
+    const fullUrl = config.host + '/uploads/' + pathStore.generatePath(req.file.filename)
+
     const data = {
       Receipt: [
         {
-          url: config.host + '/' + req.file.path
+          url: fullUrl
         }
       ]
     }
 
-    db.updateTx(req.params.id, data).then((result) => {
-      setTimeout(() => {
-        fs.unlink(req.file.path, (err) => {
-          if (err) {
-            console.log(err)
-            res.status(500)
-          }
-
-          console.log('Deleted file at ' + req.file.path)
-          res.status(200)
-        })
-      }, 10000) // Delete after 10 seconds
-    }).finally(() => {
+    db.updateTx(req.params.id, data).finally(() => {
       res.status(200).send(req.file);
     })
   }

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const multer = require('multer')
 const mime = require('mime-types')
-const fs = require('fs')
 const app = express.Router()
 
 const storage = multer.diskStorage({

--- a/src/routes/uploads.js
+++ b/src/routes/uploads.js
@@ -1,0 +1,31 @@
+const express = require('express')
+const fs = require('fs')
+const path = require('path')
+const app = express.Router()
+
+const pathStore = require('@libs/pathstore')
+
+app.get('/:path', (req, res) => {
+  const realPath = pathStore.getPath(req.params.path)
+  const absPath = path.join(
+    __dirname,
+    '../../temp/uploaded/',
+    realPath
+  )
+
+  res.sendFile(absPath, (err) => {
+    if (err) {
+      console.log(err)
+    } else {
+      fs.unlink(absPath, (err) => {
+        if (err) {
+          console.log(err)
+        }
+
+        console.log('Deleted file at ' + absPath)
+      })
+    }
+  })
+})
+
+module.exports = app


### PR DESCRIPTION
Updates:

* Uploaded files now generate a random, one-time URL under `/temp/uploaded`, accessible via endpoint `/uploads`
* The file now gets deleted **after** the send stream is complete. 